### PR TITLE
update Factory.float to limit precision

### DIFF
--- a/lib/much-factory.rb
+++ b/lib/much-factory.rb
@@ -12,8 +12,9 @@ module MuchFactory
     type_cast(Random.integer(max), :integer)
   end
 
-  def float(max = nil)
-    type_cast(Random.float(max), :float)
+  def float(max = nil, precision: Factory.integer(5))
+    factor = (10 ** precision).to_f
+    (type_cast(Random.float(max), :float) * factor).round / factor
   end
 
   DAYS_IN_A_YEAR = 365

--- a/test/unit/much-factory_tests.rb
+++ b/test/unit/much-factory_tests.rb
@@ -39,6 +39,14 @@ module MuchFactory
       assert_that(float).equals(0.0)
     end
 
+    should "allow passing a precision using `float`" do
+      float = subject.float(2, precision: 2)
+      assert_that((float * 100).round / 100.0).equals(float)
+
+      float = subject.float(0, precision: 2)
+      assert_that(float).equals(0.00)
+    end
+
     should "return a random date using `date`" do
       assert_that(subject.date).is_kind_of(Date)
     end


### PR DESCRIPTION
This helps when comparing floats. Full, unlimited Floats are very
difficult to compare with equality checks. Limiting precision on
floats like this makes for friendlier Factory float values.
